### PR TITLE
Remove google analytics code

### DIFF
--- a/src/static/js/submit-a-complaint.js
+++ b/src/static/js/submit-a-complaint.js
@@ -56,7 +56,6 @@ if ('onhashchange' in window) {
             // Analytics
             if( prev_hash_val != location.hash ) {
                 prev_hash_val = location.hash;
-                _gaq.push(['_trackPageview', location.pathname + location.search + location.hash]);
             }
         });
 


### PR DESCRIPTION
Google analytics code has been removed from base_update template, so a javascript
error occurs when an attempt to access _gaq variable happens in event handler.


## Removals

- Google analytics code from event handler in `submit-a-complaint.js`

## Testing

-

## Review

- @cfarm 



## Screenshots



## Notes

-

## Todos

-

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

