### PR TITLE
adapt setup.py to use new cfgov-setup package.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,6 @@ setup(
     ],
     long_description=read_file('README.md'),
     zip_safe=False,
-    setup_requires=['cfgov-setup'],
+    setup_requires=['cfgov-setup==1.2',],
     frontend_build_script= 'setup.sh',
 )

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,5 @@
 import os
 from setuptools import setup
-from subprocess import call
-from setuptools import Command
-from distutils.command.build_ext import build_ext as _build_ext
-from setuptools.command.bdist_egg import bdist_egg as _bdist_egg
-from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
 
 
 def read_file(filename):
@@ -16,43 +11,6 @@ def read_file(filename):
     except IOError:
         return ''
 
-
-class build_frontend(Command):
-    """ A command class to run `setup.sh` """
-    description = 'build front-end JavaScript and CSS'
-    user_options = []
-
-    def initialize_options(self):
-        pass
-
-    def finalize_options(self):
-        pass
-
-    def run(self):
-        print __file__
-        call(['sh', './setup.sh'],
-                cwd=os.path.dirname(os.path.abspath(__file__)))
-
-
-class build_ext(_build_ext):
-    """ A build_ext subclass that adds build_frontend """
-    def run(self):
-        self.run_command('build_frontend')
-        _build_ext.run(self)
-
-
-class bdist_egg(_bdist_egg):
-    """ A bdist_egg subclass that runs build_frontend """
-    def run(self):
-        self.run_command('build_frontend')
-        _bdist_egg.run(self)
-
-
-class bdist_wheel(_bdist_wheel):
-    """ A bdist_wheel subclass that runs build_frontend """
-    def run(self):
-        self.run_command('build_frontend')
-        _bdist_wheel.run(self)
 
 setup(
     name='complaintdatabase',
@@ -76,10 +34,6 @@ setup(
     ],
     long_description=read_file('README.md'),
     zip_safe=False,
-    cmdclass={
-        'build_frontend': build_frontend,
-        'build_ext': build_ext,
-        'bdist_egg': bdist_egg,
-        'bdist_wheel': bdist_wheel,
-    },
+    setup_requires=['cfgov-setup'],
+    do_frontend_build= True,
 )

--- a/setup.py
+++ b/setup.py
@@ -35,5 +35,5 @@ setup(
     long_description=read_file('README.md'),
     zip_safe=False,
     setup_requires=['cfgov-setup'],
-    do_frontend_build= True,
+    frontend_build_script= 'setup.sh',
 )


### PR DESCRIPTION
Short description explaining the high-level reason for the pull request
## Additions
- adds setup.py keywords to invoke new centralized front-end build code
## Removals
- the old setup.py code for triggering front-end builds
## Testing
- you should be able to `pip wheel /path/to/this/repo`. Unzip the wheel in a temporary directory and inspect the result, you should see all build assets.
