### PR TITLE
Quick tweak to use cfpb version of django-assets

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
     "ie8": "https://github.com/WebReflection/ie8.git"
   },
   "devDependencies": {
-    "django-assets": "https://github.com/virginiacc/django-assets.git",
+    "django-assets": "https://github.com/cfpb/django-assets.git",
     "respond": "~1.4.2"
   }
 }


### PR DESCRIPTION
The change _there_, is to remove some broken references to the US flag png:

https://github.com/cfpb/django-assets/commit/a21abf69abe58cf8dc3fca971b49ac542d676ae2
