### PR TITLE
Copy updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased][unreleased]
 - Added travis and coveralls setup
 - Updated the download 4x4 codes for Money transfers
+- Copy updates on `submit-a-complaint` and `process`
 
 ## [1.2.2] - 2016-06-06
 ### Fixed

--- a/complaint/templates/process.html
+++ b/complaint/templates/process.html
@@ -85,7 +85,7 @@
                     <div class="content-l_col content-l_col-3-4">
                         <h2><strong>5.</strong> Consumer review</h2>
                         <p class="short-desc">
-                            We will let you know when the company responds. You can review that response and give us feedback.
+                            We will let you know when the company responds. You’ll be able to review the company’s response and will have 60 days to give us feedback about the response.
                         </p>
                     </div>
                 </div>

--- a/complaint/templates/submit-a-complaint.html
+++ b/complaint/templates/submit-a-complaint.html
@@ -568,7 +568,7 @@
             <h2>What happens after I submit a complaint?</h2>
             <div>
               <p>We’ll forward your complaint to the company and work to get a response. After we forward your complaint, the company has 15 days to respond to you and the CFPB. Companies are expected to close all but the most complicated complaints within 60 days.</p>
-              <p>You’ll be able to review the response and give us feedback. If we find that another agency would be better able to assist, we will forward your complaint and let you know.</p>
+              <p>You’ll be able to review the company’s response and will have 60 days to give us feedback about the response. If we find that another agency would be better able to assist, we will forward your complaint and let you know.</p>
             </div>
             <a href="/complaint/process/" class="btn btn__super btn__secondary">Learn more</a>
           </div>


### PR DESCRIPTION
Update language around complaint response review period (ghe 355)

## Changes

- Copy updates in `submit-a-complaint` and `process`

## Review
- @cfarm
- @contolini 
- @sebworks 

## Screenshots
`/complaint/process/` page copy update:
<img width="765" alt="screen shot 2016-10-06 at 11 32 14 am" src="https://cloud.githubusercontent.com/assets/778171/19165679/99f2eaec-8bb9-11e6-8df9-82b40a6d98da.png">

`/complaint/` page copy update:
<img width="1205" alt="screen shot 2016-10-06 at 11 31 47 am" src="https://cloud.githubusercontent.com/assets/778171/19165690/a4526710-8bb9-11e6-8903-1927aeaa3a7a.png">


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

