### PR TITLE
Add links to CCDB crosswalk PDFs

### DIFF
--- a/complaintdatabase/templates/landing-page.html
+++ b/complaintdatabase/templates/landing-page.html
@@ -88,13 +88,13 @@
             </p>
             <ul class="list list__links">
               <li class="list_item">
-                <a class="list_link icon-link icon-link__download" href="#">
-                  <span class="icon-link_text">Learn more about changes to products and issues</span>
+                <a class="list_link icon-link icon-link__download" href="http://files.consumerfinance.gov/f/documents/201704_cfpb_Summary_of_Product_and_Sub-product_Changes.pdf">
+                  <span class="icon-link_text">Learn more about complaint form changes to products and sub-products</span>
                 </a>
               </li>
               <li class="list_item">
-                <a class="list_link icon-link icon-link__download" href="#">
-                  <span class="icon-link_text">View full list of products, sub-products, issues, and sub-issues</span>
+                <a class="list_link icon-link icon-link__download" href="http://files.consumerfinance.gov/f/documents/201704_cfpb_Consumer_Complaint_Form_Product_and_Issue_Options.pdf">
+                  <span class="icon-link_text">View full list of complaint form products, sub-products, issues and sub-issues</span>
                 </a>
               </li>
             </ul>
@@ -109,7 +109,7 @@
               <p>The Consumer Complaint Database is a collection of complaints on a range of consumer financial products and services, sent to companies for response. We don’t verify all the facts alleged in these complaints, but we take steps to confirm a commercial relationship between the consumer and the company. <span class="publication-criteria"><a class="list_link icon-link icon-link__download" href="http://files.consumerfinance.gov/f/201303_cfpb_Final-Policy-Statement-Disclosure-of-Consumer-Complaint-Data.pdf">
                 <span class="icon-link_text">See publication criteria</span>
               </a></span></p>
-              <p>Since we started accepting complaints in July 2011, we’ve helped consumers connect with financial companies to understand issues with their mortgages, fix errors on their credit reports, stop unlawful calls from debt collectors, and get direct responses about problems with their credit cards, checking and savings accounts, student loans, and more. We analyze the data to identify trends and problems in the marketplace to help us do a better job supervising companies, enforcing federal consumer financial laws and writing rules and regulations. We publish reports on complaints and share information with state and federal agencies.</p>
+              <p>Since we started accepting complaints in July 2011, we’ve helped consumers connect with financial companies to understand issues with their mortgages, fix errors on their credit reports, stop harassment from debt collectors, and get direct responses about problems with their credit cards, checking and savings accounts, student loans, and more. We analyze the data to identify trends and problems in the marketplace to help us do a better job supervising companies, enforcing federal consumer financial laws and writing rules and regulations. We publish reports on complaints and share information with state and federal agencies.</p>
               <ul class="list list__links">
                 <li class="list_item">
                   <a class="list_link" href="/complaint/data-use/#reports">


### PR DESCRIPTION
Add links to the two new PDFs that were created for this page

## Additions

- Added the URL to the summary of product and sub-product changes
- Added the URL to the full list of complaint form products, sub-products, issues, and sub-issues

## Changes

- Changed the wording of both PDF links to better describe the documents to which they link
- Updated a bit of text in the "about the data" section to use the final, approved language 

## Testing

- The "Learn more about complaint form changes to products and sub-products" link should open a nine-page PDF titled "CFPB Summary of product and sub-product changes"
- The "View full list of complaint form products, sub-products, issues and sub-issues" link should open a 35-page PDF titled "Consumer Complaint Form Product and Issue Options"
- The first line in the second paragraph of the "about the data" section should say "Since we started accepting complaints in July 2011, we’ve helped consumers connect with financial companies to understand issues with their mortgages, fix errors on their credit reports, stop harassment from debt collectors, and get direct responses..."

## Todos

- Once this all gets released, we should update the screenshots and description in the readme to reflect all the recent changes.

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
