### PR TITLE
Fix tests for running with cfgov-refresh

### DIFF
--- a/ccdb/urls.py
+++ b/ccdb/urls.py
@@ -3,9 +3,7 @@ from django.contrib import admin
 admin.autodiscover()
 
 urlpatterns = [
-    url(r'^complaint/', include('complaint.urls',
-                                namespace='complaints')),
-    url(r'^complaintdatabase/', include('complaintdatabase.urls',
-                                        namespace='complaintdatabase')),
+    url(r'^complaint/', include('complaint.urls')),
+    url(r'^complaintdatabase/', include('complaintdatabase.urls')),
     url(r'^admin/', include(admin.site.urls)),
 ]

--- a/complaint/tests.py
+++ b/complaint/tests.py
@@ -50,6 +50,6 @@ class URLTest(TestCase):
 
     def test_complaint_urls(self):
         for url_name in self.url_names:
-            response = client.get(reverse("{}".format(url_name)))
+            response = client.get(reverse(url_name))
             self.assertEqual(response.status_code, 200)
             self.assertTrue('base_template' in response.context_data.keys())

--- a/complaint/tests.py
+++ b/complaint/tests.py
@@ -1,6 +1,7 @@
-from django.test import RequestFactory, TestCase, Client
-from .views import SubmitView, DataUseView, ProcessView
 from django.core.urlresolvers import reverse
+from django.test import RequestFactory, TestCase, Client
+
+from .views import SubmitView, DataUseView, ProcessView
 
 client = Client()
 
@@ -49,6 +50,6 @@ class URLTest(TestCase):
 
     def test_complaint_urls(self):
         for url_name in self.url_names:
-            response = client.get(reverse("complaints:{}".format(url_name)))
+            response = client.get(reverse("{}".format(url_name)))
             self.assertEqual(response.status_code, 200)
             self.assertTrue('base_template' in response.context_data.keys())

--- a/complaintdatabase/tests.py
+++ b/complaintdatabase/tests.py
@@ -1,12 +1,17 @@
 import collections
-from mock import patch, Mock, MagicMock, mock_open
-
-from requests.exceptions import ConnectionError
-from django.test import RequestFactory, TestCase
-from django.core.urlresolvers import reverse
-from django.test import Client
 from datetime import datetime
 from StringIO import StringIO
+from unittest import skipIf
+
+from mock import patch, Mock, MagicMock, mock_open
+
+from django.conf import settings
+from django.core.urlresolvers import reverse
+from django.test import RequestFactory, TestCase
+from django.test import Client
+
+from requests.exceptions import ConnectionError
+
 from .views import (LandingView, DocsView, get_narratives_json,
                     format_narratives, get_stats, get_count_info,
                     is_data_not_updated)
@@ -33,11 +38,12 @@ class LandingViewTest(TestCase):
         self.assertTrue('total_complaints' in response.context_data.keys())
         self.assertTrue('timely_responses' in response.context_data.keys())
 
+    @skipIf(not hasattr(settings, 'STANDALONE'), "not running standlone")
     @patch('complaintdatabase.views.flag_enabled')
     def test_demo_json(self, mock_flag_enabled):
         """Test demo version of landing page"""
         mock_flag_enabled.return_value = True
-        response = client.get(reverse("complaintdatabase:ccdb-demo",
+        response = client.get(reverse("ccdb-demo",
                                       kwargs={'demo_json': 'demo.json'}))
         self.assertEqual(response.status_code, 200)
         self.assertTrue('base_template' in response.context_data.keys())

--- a/complaintdatabase/tests.py
+++ b/complaintdatabase/tests.py
@@ -38,7 +38,8 @@ class LandingViewTest(TestCase):
         self.assertTrue('total_complaints' in response.context_data.keys())
         self.assertTrue('timely_responses' in response.context_data.keys())
 
-    @skipIf(not hasattr(settings, 'STANDALONE'), "not running standlone")
+    @skipIf(not getattr(settings, 'STANDALONE', 'False'),
+            "not running standlone")
     @patch('complaintdatabase.views.flag_enabled')
     def test_demo_json(self, mock_flag_enabled):
         """Test demo version of landing page"""


### PR DESCRIPTION
When running the complaint tests with https://github.com/cfpb/cfgov-refresh/, the there are a couple of minor issues with URL resolving. I've solved those by removing the hard-coded namespaces (we don't currently namespace in cfgov-refresh—this is something we can come back to), and by skipping a demo test that runs against a URL that isn't used when running as part of cfgov-refresh.

Part of GHE/CFGOV/platform/issues/798

## Changes

- Modified tests to run with cfgov-refresh

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
