### PR TITLE
Fix a few typos on the CCDB page

### DIFF
--- a/complaintdatabase/templates/landing-page.html
+++ b/complaintdatabase/templates/landing-page.html
@@ -81,7 +81,7 @@
               Recent changes to the Consumer Complaint Database
             </h3>
             <p>
-              In April 2017 we updated the form consumers use to submit complaints. The changes include reorganizing how products, sub-products, issues, and sub-issues are grouped and making some plain language improvements.
+              In April 2017 we updated the form consumers use to submit complaints. The changes include making some plain language improvements and reorganizing how products, sub-products, issues, and sub-issues are grouped.
             </p>
             <p>
               The Consumer Complaint Database shows the consumer’s original product, sub-product, issue, and sub-issue selections consistent with the options available on the form at the time the consumer submitted the complaint.
@@ -94,7 +94,7 @@
               </li>
               <li class="list_item">
                 <a class="list_link icon-link icon-link__download" href="http://files.consumerfinance.gov/f/documents/201704_cfpb_Consumer_Complaint_Form_Product_and_Issue_Options.pdf">
-                  <span class="icon-link_text">View full list of complaint form products, sub-products, issues and sub-issues</span>
+                  <span class="icon-link_text">View full list of complaint form products, sub-products, issues, and sub-issues</span>
                 </a>
               </li>
             </ul>


### PR DESCRIPTION
Fix a few typos in the new CCDB landing page content

## Changes

- Swap the order of the changes in the update section to be more readable
- Add a serial comma to comply with our style guide