### PR TITLE
allow technical issues banner to be enabled on-demand

### DIFF
--- a/complaintdatabase/templates/landing-page.html
+++ b/complaintdatabase/templates/landing-page.html
@@ -5,18 +5,21 @@
 {% block title %}Consumer Complaint Database{% endblock %}
 
 {% block content %}
-
 <div id="ccdb-landing">
   <!--
     If the data has not been updated, add class 'show-data-notification' to cf-notification
     If narratives have not been updated, add class 'show-narratives-notification'-->
-  <div class="cf-notification cf-notification__warning {% if data_down %} show-data-notification {% elif narratives_down %} show-narratives-notification {% endif %} ">
+    <div class="cf-notification cf-notification__warning {% if data_down %} show-data-notification {% elif narratives_down %} show-narratives-notification  {% endif %}">
     <div class="wrapper wrapper__match-content cf-notification_wrapper">
       <span class="cf-notification_icon cf-notification_icon__warning cf-icon cf-icon-error-round"></span>
       <div class="cf-notification_text">
         <p class="data-text">We're currently experiencing technical issues that have delayed the refresh of data in the Consumer Complaint database.</p>
         <p class="narratives-text">We're currently experiencing technical issues that have delayed the refresh of consumer complaint narratives in the Consumer Complaint database.</p>
-        <p class="short-desc">We expect to refresh the data in the next few days.</p>
+        <p class="short-desc">{% if technical_issues %}
+        We expect a refresh of the data and restoration of access soon. 
+        {% else %}
+        We expect to refresh the data in the next few days.
+        {% endif %}</p>
       </div>
     </div>
   </div>

--- a/complaintdatabase/views.py
+++ b/complaintdatabase/views.py
@@ -5,6 +5,12 @@ from django.shortcuts import render
 from django.views.generic import View, TemplateView
 from django.conf import settings
 
+from flags.state import (
+    flag_state,
+    flag_enabled,
+    flag_disabled,
+)
+
 try:
     STANDALONE = settings.STANDALONE
 except:  # pragma: no cover
@@ -43,6 +49,7 @@ class LandingView(TemplateView):
          context['timely_responses']) = get_count_info()
         (context['data_down'],
          context['narratives_down']) = is_data_not_updated(res_json)
+        context['technical_issues'] = flag_enabled('CCDB_TECHNICAL_ISSUES')
         return context
 
 
@@ -222,7 +229,7 @@ def get_now():
 
 
 def is_data_not_updated(res_json):
-    data_down = False
+    data_down = flag_enabled('CCDB_TECHNICAL_ISSUES')
     narratives_down = False
     # show notification starting fifth business day data has not been updated
     # M-Th, data needs to have been updated 6 days ago; F-S, preceding Monday

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Django==1.8.14
 requests==2.7.0
-wagtail-flags==1.0.3
+wagtail-flags==2.0.5


### PR DESCRIPTION
We have an urgent request to enable the technical issues banner-- with these changes, it can be flipped on and off with a feature flag

## Additions

-

## Removals

-

## Changes

-

## Testing

-

## Review

- @user

[Preview this PR without the whitespace changes](?w=0)

## Screenshots


## Notes

-

## Todos

-

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
