### PR TITLE
build wheels and attach them to new releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,31 @@
 language: python
-
 python:
-  - "2.7"
-
+- '2.7'
+nodejs: 6
 sudo: false
-
 env:
-  - DEPLOY_ENV=DEV
-  - DJANGO_SETTINGS_MODULE=ccdb.settings
-
+- DEPLOY_ENV=DEV
+- DJANGO_SETTINGS_MODULE=ccdb.settings
 install:
-  # Project configuration requirements.
-  - pip install -r requirements.txt
-  - pip install -r test_requirements.txt
-  - pip install coveralls
-
+- pip install -r requirements.txt
+- pip install -r test_requirements.txt
+- pip install coveralls
+before_script:
+- npm install -g bower gulp-cli
+- bower install
 script:
-  - ./travis-prep.sh
-  - coverage run --source='.' manage.py test
-
+- ./travis-prep.sh
+- coverage run --source='.' manage.py test
+- python2.7 setup.py bdist_wheel
+- ls dist/*
 after_success:
-  - coveralls
+- coveralls
+deploy:
+  provider: releases
+  skip_cleanup: true
+  api_key:
+    secure: V8MCeolsM1iNuKOkQ6+hNsnwJuZw3nNjaLvWGJ9oPVA/FporQtevCMqdsTGJqRcvdLl/Xl7G+7NmysNTQCdqcxB1b1DkGRYg2orRod4eRz75j+YfkMejdEgWIkmfE3WIyET8D1sXi3mEGCv5SWiBvoJhrP+bNnj466Zd0l0mBn6H6h92MAkF7Y+OiRhks5FjhqaaXdunluZHkE9ehYCIaH7grfHgBRXV8f6g/zPd8+DCJWlSZ/dud1FsyRzWYUSHIkGWTa5F+O2s0HuzSghjP9EOFu8hb1Oqsu2OUJ8jbrZHDIO0uIvz0Z72CDxZg0/PEY9Nl+AUycxUUeCE/TRhL5r4wIk1yh0NYOLHQdgXMgY0ssFYGRJXWX9hw6EwlwiFLjvJuzpjS8eABNm+S5E3xrpfH33062zZSMOZKIZEVkv8LvOkc22xmYu1laphlLZ/bC9FNGLjTNxaEoQFzrmcoZ8U807Bhh1lcFMdJA/f77ZioRXpdhAJkIlsiGJPv3QHPnfH8fttuyN+bEBIYWhVn+WJzNHI4lNuFgdnmkmNbQc8fxx7aEZTCaapMojZ/KHvI8JWG4yYdsKvfNqWA6SH53GTp9bRNHME/UBYl2S8kr966iXC+p3AW0fQqZd5IAnVzV5sKw0cW7SpXexFnFP16hejAzez7apgrI83NrHcVw8=
+  file_glob: true
+  file: dist/*.whl
+  on:
+    tags: true

--- a/setup.py
+++ b/setup.py
@@ -14,12 +14,12 @@ def read_file(filename):
 
 setup(
     name='complaintdatabase',
-    version='1.3.3',
+    version_format='{tag}.dev{commitcount}+{gitsha}',
     author='CFPB',
     author_email='tech@cfpb.gov',
     maintainer='cfpb',
     maintainer_email='tech@cfpb.gov',
-    packages=['complaint_common','complaint','complaintdatabase'],
+    packages=['complaint_common', 'complaint', 'complaintdatabase'],
     include_package_data=True,
     description=u'CCDB Landing Pages',
     classifiers=[
@@ -34,6 +34,6 @@ setup(
     ],
     long_description=read_file('README.md'),
     zip_safe=False,
-    setup_requires=['cfgov-setup==1.2',],
-    frontend_build_script= 'setup.sh',
+    setup_requires=['cfgov-setup==1.2', 'setuptools-git-version==1.0.3'],
+    frontend_build_script='setup.sh',
 )


### PR DESCRIPTION
With this merged, new releases of complaint will automatically trigger a Travis build that will generate the deployment package (wheel) and attach it to the release page

## Additions

- Travis 'deployment' config, and some additional lines to install Node 6 and glup
- added code to setup.py to allow for the app to infer it's own version number from git.


## Notes

-

## Todos

-

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
