### PR TITLE
Remove deprecated narrative formatting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
 - '2.7'
-nodejs: 6
+nodejs: 8
 sudo: false
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ python:
 nodejs: 6
 sudo: false
 env:
-- DEPLOY_ENV=DEV
-- DJANGO_SETTINGS_MODULE=ccdb.settings
+  global:
+    - DEPLOY_ENV=DEV
+    - DJANGO_SETTINGS_MODULE=ccdb.settings
 install:
 - pip install -r requirements.txt
 - pip install -r test_requirements.txt

--- a/complaintdatabase/tests.py
+++ b/complaintdatabase/tests.py
@@ -12,8 +12,9 @@ from django.test import Client
 
 from requests.exceptions import ConnectionError
 
-from .views import (LandingView, DocsView, get_narratives_json,
-                    format_narratives, get_stats, is_data_not_updated)
+from .views import (LandingView, DocsView, get_narratives_json, get_stats,
+                    is_data_not_updated)
+
 
 MOCK_404 = ConnectionError(Mock(return_value={'status': 404}), 'not found')
 client = Client()
@@ -30,7 +31,6 @@ class LandingViewTest(TestCase):
         response = LandingView.as_view()(request)
         self.assertEqual(response.status_code, 200)
         self.assertTrue('base_template' in response.context_data.keys())
-        self.assertTrue('narratives' in response.context_data.keys())
         self.assertTrue('stats' in response.context_data.keys())
 
     @skipIf(True, "not running with feature flags")
@@ -40,7 +40,6 @@ class LandingViewTest(TestCase):
                                       kwargs={'demo_json': 'demo.json'}))
         self.assertEqual(response.status_code, 200)
         self.assertTrue('base_template' in response.context_data.keys())
-        self.assertTrue('narratives' in response.context_data.keys())
         self.assertTrue('stats' in response.context_data.keys())
 
 
@@ -84,48 +83,6 @@ class NarrativeJsonTest(TestCase):
             self.assertEqual(res_json, {})
             self.assertIn('ValueError', fakeOutput.getvalue())
             self.assertTrue(mock_get.call_count == 1)
-
-
-class FormatNarrativesTest(TestCase):
-    def test_format_narratives(self):
-        input_json = {
-            'bank_accounts': {'date_received': '2015-04-08T20:32:15',
-                              'tags': ['Older American', 'Servicemember']},
-            'credit_cards': {'date_received': '2015-04-08T20:32:16',
-                             'tags': ['Older American', 'Servicemember']},
-            'credit_reporting': {'date_received': '2015-04-08T20:32:17',
-                                 'tags': ['Older American', 'Servicemember']},
-            'debt_collection': {'date_received': '2015-04-08T20:32:18',
-                                'tags': ['Older American', 'Servicemember']},
-            'money_transfers': {'date_received': '2015-04-08T20:32:19',
-                                'tags': ['Older American', 'Servicemember']},
-            'mortgages': {'date_received': '2015-04-08T21:32:15',
-                          'tags': ['Older American', 'Servicemember']},
-            'other_financial_services': {'date_received':
-                                         '2015-04-09T20:32:15'},
-            'payday_loans': {'date_received': '2015-04-10T20:32:15'},
-            'prepaid_cards': {'date_received': '2015-04-11T20:32:15'},
-            'student_loans': {'date_received': '2015-04-12T20:32:15'},
-            'other_consumer_loans': {'date_received': '2015-04-13T20:32:15'}
-        }
-        sorted_titles = ['Bank account', 'Credit card',
-                         'Credit reporting', 'Debt collection',
-                         'Money transfer or virtual currency', 'Mortgage',
-                         'Other financial service', 'Payday loan',
-                         'Prepaid card', 'Student loan',
-                         'Vehicle / consumer loan']
-        res = format_narratives(input_json)
-        self.assertEqual(len(res), 11)
-        res_titles = sorted([entry['title'] for entry in res])
-        self.assertEqual(res_titles, sorted_titles)
-        for date in [entry['date'] for entry in res]:
-            self.assertEqual(type(date), datetime)
-
-    def test_invalid_json_format_narratives(self):
-        with patch('sys.stdout', new=StringIO()) as fakeOutput:
-            res = format_narratives({})
-            self.assertEqual(res, [])
-            self.assertIn('KeyError', fakeOutput.getvalue().strip())
 
 
 class GetStatsTest(TestCase):

--- a/complaintdatabase/views.py
+++ b/complaintdatabase/views.py
@@ -43,7 +43,6 @@ class LandingView(TemplateView):
             res_json = get_narratives_json(demo_json=kwargs['demo_json'])
         else:
             res_json = get_narratives_json()
-        context['narratives'] = format_narratives(res_json)
         context['stats'] = get_stats(res_json)
         (context['data_down'],
          context['narratives_down']) = is_data_not_updated(res_json)
@@ -87,90 +86,6 @@ def get_narratives_json(demo_json=None):
         print(e)
         res_json = {}
     return res_json
-
-
-def format_narratives(res_json):
-    """Set up label and css values for page."""
-    narratives = []
-
-    # Additional data needed to output the narratives on the page
-    # title, css, and icon are required
-    # optional 'tooltip' determines text that displays on section button hover
-    # 'tooltip' defaults to title
-    narrative_types = [
-        {'key': 'bank_accounts',
-         'title': 'Bank account',
-         'css': 'bank-account',
-         'icon': 'bank-account'},
-        {'key': 'credit_cards',
-         'title': 'Credit card',
-         'css': 'credit-card',
-         'icon': 'credit-card'},
-        {'key': 'credit_reporting',
-         'title': 'Credit reporting',
-         'css': 'credit-reporting',
-         'icon': 'loan'},
-        {'key': 'debt_collection',
-         'title': 'Debt collection',
-         'css': 'debt-collection',
-         'icon': 'debt-collection'},
-        {'key': 'money_transfers',
-         'title': 'Money transfer or virtual currency',
-         'css': 'money-transfer',
-         'icon': 'money-transfer',
-         'tooltip': 'Money transfer/virtual currency'},
-        {'key': 'mortgages',
-         'title': 'Mortgage',
-         'css': 'mortgage',
-         'icon': 'owning-home'},
-        {'key': 'other_financial_services',
-         'title': 'Other financial service',
-         'css': 'other',
-         'icon': 'money'},
-        {'key': 'payday_loans',
-         'title': 'Payday loan',
-         'css': 'payday-loan',
-         'icon': 'payday-loan'},
-        {'key': 'prepaid_cards',
-         'title': 'Prepaid card',
-         'css': 'prepaid-card',
-         'icon': 'prepaid-cards'},
-        {'key': 'student_loans',
-         'title': 'Student loan',
-         'css': 'student-loan',
-         'icon': 'paying-college'},
-        {'key': 'other_consumer_loans',
-         'title': 'Vehicle / consumer loan',
-         'css': 'consumer-loan',
-         'icon': 'buying-car'}
-    ]
-
-    try:
-
-        for index, item in enumerate(narrative_types):
-            # get json data for this type
-            narrative = res_json[item['key']]
-
-            # extend it with the additional title/css/icon/tooltip data
-            narrative.update(item)
-
-            # format date
-            narrative['date'] = datetime.strptime(narrative['date_received'],
-                                                  "%Y-%m-%dT%H:%M:%S")
-
-            # add data for next item
-            narrative['next'] = narrative_types[(index + 1) %
-                                                len(narrative_types)]
-
-            narratives.append(narrative)
-
-    except KeyError as e:
-        print("format_narratives:KeyError")
-        print("There is problem accessing with the given key, "
-              "which probably means the json has missing data")
-        print(e)
-
-    return narratives
 
 
 def get_stats(res_json):

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "mocha-jsdom": "1.0.0",
     "object-assign": "4.0.1",
     "pretty-hrtime": "1.0.0",
-    "require-dir": "0.3.0",
+    "require-dir": "0.3.2",
     "sinon": "1.15.3",
     "sinon-chai": "2.8.0",
     "snyk": "1.13.2",


### PR DESCRIPTION
The current logic for the complaint database landing page invokes a `format_narratives` function that does some processing on narrative data pulled down from S3.

That data currently causes the following error [to be logged](https://github.com/cfpb/complaint/blob/master/complaintdatabase/views.py#L168) on every single load of the landing page:

```sh
format_narratives:KeyError
There is problem accessing with the given key, which probably means the json has missing data
'date_received'
```

This error gets printed because each narrative in the current JSON data doesn't necessarily contain that key.

In practice, this doesn't matter at all because this narrative data is never used on the landing page. It gets processed into a `narratives` variable [that gets passed into the template](https://github.com/cfpb/complaint/blob/master/complaintdatabase/views.py#L46), but that variable isn't used at all.

The JSON data is still used for stats to present the number of complaints that were resolved in a timely manner, so we still need to keep fetching of the JSON. But if the narrative data itself isn't
displayed at all, can this logic (and the frequently-appearing error) be removed?

One other minor change: the formatting of `.travis.yml` has been changed so that multiple environment variables are used globally, instead of causing two separate Travis jobs.

## Testing

- Follow the setup instructions in the README, run `./travis-prep.sh` to download necessary global templates, then run `./pytest.sh` to run unit tests.
- To run in a browser, it's easiest to `pip install` this into cfgov-refresh, and hit http://localhost:8000/data-research/consumer-complaints/.

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests
* [X] New functions include new tests
* [X] New functions are documented (with a description, list of inputs, and expected output)
* [X] Placeholder code is flagged
* [X] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
