### PR TITLE
Add noopener rel attribute to target blank links

### DIFF
--- a/complaintdatabase/templates/landing-page.html
+++ b/complaintdatabase/templates/landing-page.html
@@ -45,9 +45,9 @@
             <p>Consumers have let us know they want to share their complaint descriptions so others can learn from their experience.</p>
             <div class="btn-holder">
               {% if CCDB5_RELEASE %}
-              <p><a href="/data-research/consumer-complaints/search/?has_narrative=true" target="_blank" class="btn">Read consumer narratives</a></p>
+              <p><a href="/data-research/consumer-complaints/search/?has_narrative=true" target="_blank" rel="noopener noreferrer" class="btn">Read consumer narratives</a></p>
               {% else %}
-              <p><a href="https://data.consumerfinance.gov/d/nsyy-je5y" target="_blank" class="btn">Read consumer narratives</a></p>
+              <p><a href="https://data.consumerfinance.gov/d/nsyy-je5y" target="_blank" rel="noopener noreferrer" class="btn">Read consumer narratives</a></p>
               {% endif %}
             </div>
           </div>
@@ -56,9 +56,9 @@
             <p>View, sort, and filter data right in your browser.</p>
             <div class="btn-holder">
               {% if CCDB5_RELEASE %}
-              <p><a href="/data-research/consumer-complaints/search/" target="_blank" class="btn">View complaint data</a></p>
+              <p><a href="/data-research/consumer-complaints/search/" target="_blank" rel="noopener noreferrer" class="btn">View complaint data</a></p>
               {% else %}
-              <p><a href="https://data.consumerfinance.gov/d/s6ew-h6mp" target="_blank" class="btn">View complaint data</a></p>
+              <p><a href="https://data.consumerfinance.gov/d/s6ew-h6mp" target="_blank" rel="noopener noreferrer" class="btn">View complaint data</a></p>
               {% endif %}
             </div>
           </div>


### PR DESCRIPTION
- Adds `rel="nopener noreferrer"` to two PDF links that were missing that with `target="_blank"` (reported by @lfatty).